### PR TITLE
Cortando imagen para mostrar solo código QR

### DIFF
--- a/app/(scanQR)/scanfromimage.tsx
+++ b/app/(scanQR)/scanfromimage.tsx
@@ -21,7 +21,11 @@ export default function ScanFromImage () {
             <BackButton route='../' />
             {isUrlShorten && <Text style={styles.shorten}>URL ACORTADA</Text>}
             <Text style={styles.url} numberOfLines={4}>{obtainedURL}</Text>
-            <Image source={{ uri: uri.toString() }} style={styles.image} />
+            <Image 
+                source={{ uri: uri.toString() }} 
+                style={styles.image} 
+                resizeMode='cover'
+            />
             <ScanAlert 
                 scanStatus={scanData.scanStatus}
                 iconRoute={scanData.icon}
@@ -62,7 +66,7 @@ const styles = StyleSheet.create({
         position: 'absolute',
         top: '35%',
         width: 290,
-        height: 290,
+        height: 300,
         marginBottom: 40
     },
 })

--- a/hooks/useDocumentPicker.ts
+++ b/hooks/useDocumentPicker.ts
@@ -1,4 +1,5 @@
 import { getDocumentAsync } from "expo-document-picker";
+import { Image } from "react-native";
 import { NavigationContext } from "@/contexts/NavigationProvider";
 import { 
     BarcodeScanningResult, 
@@ -9,8 +10,14 @@ import {
     useEffect,
     useContext
 } from "react";
+import {
+    ImageManipulator,
+    ImageResult,
+    SaveFormat
+} from "expo-image-manipulator";
 
 const MIN_NUMBER_OF_FILES = 0;
+const MARGIN_SIZE = 50;
 
 export function useDocumentPicker () {
     const [showMessageError, setShowMessageError] = useState<boolean>(false);
@@ -41,16 +48,18 @@ export function useDocumentPicker () {
                 const resultUri = result.assets[MIN_NUMBER_OF_FILES].uri;
                 // Obtain QR information if it exists
                 const scannedData = await scanQR(resultUri);
-                
+
                 if (typeof scannedData === 'string') {
                     setShowMessageError(true);
                     return;
                 }
 
+                const onlyQRCodeImage = await getQRCodeFromImage(resultUri, scannedData);
+
                 router.push({
                     pathname: '/(scanQR)/scanfromimage',
                     params: { 
-                        uri: resultUri, 
+                        uri: onlyQRCodeImage?.uri ?? resultUri, 
                         qrdata: JSON.stringify(scannedData)
                     }
                 })
@@ -63,19 +72,54 @@ export function useDocumentPicker () {
     const scanQR = async (uri: string): Promise<BarcodeScanningResult | string>  => {
         try {
             // Using scanner from expo-camera
-            const scanQRCode = await scanFromURLAsync(uri, ['qr']);
+            const scanQRCode: BarcodeScanningResult[] = await scanFromURLAsync(uri, ['qr']);
 
             // If QR exists it should navigate to route
             if (scanQRCode && scanQRCode.length > MIN_NUMBER_OF_FILES) {
-                const qrData = scanQRCode[MIN_NUMBER_OF_FILES];
+                const qrData = scanQRCode[MIN_NUMBER_OF_FILES];                
                 return qrData;
             }
 
             return 'La imagen no tiene un código QR.'
         } catch (error) {
-            console.error('Error al escanear código QR.', error)
-            return 'Error al escanear código QR.'
+            throw new Error(`Ocurrio un error al escanear la imagen${error}`);
         }
+    }
+
+    const getQRCodeFromImage = async (uri: string, QRCodeInformation: BarcodeScanningResult): Promise<ImageResult | null> => {
+        // Obtaining bounds to calculate QRcode position and size
+        const { bounds } = QRCodeInformation;
+
+        // Obtaining dimensions of original image
+        const { width, height } = await Image.getSize(uri);        
+
+        // Obtaining dimensions of QRcode
+        const QRWidth = bounds.size.width + (MARGIN_SIZE * 2);
+        const QRHeight = bounds.size.height + (MARGIN_SIZE * 2);
+        const QROriginX = bounds.origin.x - MARGIN_SIZE;
+        const QROriginY = bounds.origin.y - MARGIN_SIZE;
+
+        // Checking if is necessary to crop image
+        if (QRWidth > width || QRHeight > height) return null;
+
+        // Cutting image to get only QRcode
+        const manipulateImage = ImageManipulator.manipulate(uri)
+        
+        const croppedImage = await manipulateImage.crop(
+            {
+                height: QRHeight,
+                originX: QROriginX,
+                originY: QROriginY,
+                width: QRWidth
+            }
+        ).renderAsync();
+        // Saving cropped image 
+        const result = await croppedImage.saveAsync({
+            format: SaveFormat.PNG
+        })
+
+        return result;
+        
     }
 
     return { pickImageAndScan, showMessageError };


### PR DESCRIPTION
### TRABAJO REALIZADO EN ESTE RAMA
- Se instaló la librería _**expo-image-manipulator**_ para manipular la imagen seleccionada por el usuario.
- Se implemento un método para recortar un código QR de una imagen original
- Se añadió una condición, donde si el tamaño del recorte de un código QR + el margen que se provee es mayor al tamaño de la imagen original, entonces se usará la imagen original.
**Ejemplo:** Como ejemplo se tienen imagenes seleccionada de servicios de banca que contiene otros datos aparte de un código QR, d
**ANTES** 
Por ejemplo en este caso, se puede observar datos como el nombre de la banca
![WhatsApp Image 2025-04-06 at 18 12 11](https://github.com/user-attachments/assets/95711411-2a3c-4fd7-887a-56e57d612b4c)
Este otro caso se muestra más datos aparte del código QR, con lo cual queda diferente por cada código QR
![40dfbfb9-f9c0-453b-bb33-b9e15e0906d0](https://github.com/user-attachments/assets/ecab3555-6026-4850-84a8-a1ebc5665553)


**DESPUES**
Ahora no importa la imagen seleccionada, solo se mostrará el código QR
![WhatsApp Image 2025-04-07 at 09 54 33](https://github.com/user-attachments/assets/89a35517-943f-4b8d-a53d-25f9ea2e0337)


