### PR TITLE
Ajustando ancho del contenedor de URL y alineado texto al medio

### DIFF
--- a/app/(scanQR)/camera.tsx
+++ b/app/(scanQR)/camera.tsx
@@ -63,6 +63,7 @@ export const styles = StyleSheet.create({
     container: {
         width: '100%',
         height: '100%',
+        display: 'flex',
         justifyContent: 'center',
         alignContent: 'center',
         position: 'relative',
@@ -85,12 +86,15 @@ export const styles = StyleSheet.create({
 
     url: {
         position: 'absolute',
-        top: '15%',
-        left: '15%',
-        width: 300,
+        top: '14.5%',
+        left: 30,
+        width: 350,
         color: '#fff',
         textDecorationLine: 'underline',
+        textAlign: 'center',
         fontSize: 20,
-        zIndex: 2
+        zIndex: 2,
+        marginLeft: 'auto',
+        marginRight: 'auto'
     }
 });


### PR DESCRIPTION
### ANTES DE LA CORRECCIÓN

- URLs largas se muestran mal justificadas

![WhatsApp Image 2025-04-08 at 19 52 57 (1)](https://github.com/user-attachments/assets/91eaedc2-3d19-4aad-8f19-cfe2c2041ec2)
### DESPUES DE LA CORRECCIÓN
- Se ajusto el tamaño del contenido de la URL en la pantalla de escaneo, además de que la alineación de la URL será al medio.
- 
![WhatsApp Image 2025-04-08 at 20 22 20](https://github.com/user-attachments/assets/bd0269c6-7f0f-41de-838f-335354c0f264)
